### PR TITLE
Added 'cache' option

### DIFF
--- a/comm.js
+++ b/comm.js
@@ -292,7 +292,10 @@
       cb = cb || obj;
 
       var opts = libs.merge(obj, defaults);
-
+      if (opts.cache) {
+        // Added cache busting to the url using current timestamp
+        opts.url = opts.url + ((/\?/).test(opts.url) ? "&" : "?") + new Date().getTime();
+      }
       setup.init(opts, cb);
     }();
 


### PR DESCRIPTION
Hey @jas- , I really like this library. Thank you.

I just added a 'cache' a option which adds a timestamp to the end of the request url to force busting of ajax caching. This is because IE10/11 will cache ajax get results by default and can cause a lot of headaches :cry: 

It could be used like this:

``` javascript
comm({
    method: 'get',
    url: 'http://localhost:3000',
    cache: true
},
function(err, response){
    if (err) throw err;
    console.log(response);
});
```

Let me know your thoughts.
